### PR TITLE
feat: exposing API client in the Agent struct

### DIFF
--- a/axon_agent.go
+++ b/axon_agent.go
@@ -28,7 +28,7 @@ import (
 type Agent struct {
 	DispatchId string
 
-	client grpcClient
+	Client grpcClient
 
 	handlers           []*handlerInfo
 	registeredHandlers map[string]*handlerInfo
@@ -61,7 +61,7 @@ func NewAxonAgent(options ...Option) *Agent {
 	}
 
 	a.logger = logger
-	a.client = newGrpcClient(ao.host, ao.port, logger)
+	a.Client = newGrpcClient(ao.host, ao.port, logger)
 	a.registeredHandlers = make(map[string]*handlerInfo)
 	return a
 }
@@ -170,7 +170,7 @@ func (a *Agent) RegisterInvocableHandler(handler InvocableHandler, invokeOptions
 
 func (a *Agent) registerHandler(info *handlerInfo) (string, error) {
 
-	stub := a.client.agent()
+	stub := a.Client.Agent()
 	if stub == nil {
 		return "", fmt.Errorf("failed to create agent connection")
 	}
@@ -192,7 +192,7 @@ func (a *Agent) registerHandler(info *handlerInfo) (string, error) {
 // UnregisterHandler unregisters a handler by id
 func (a *Agent) UnregisterHandler(id string) error {
 
-	stub := a.client.agent()
+	stub := a.Client.Agent()
 	if stub == nil {
 		return fmt.Errorf("failed to create agent connection")
 	}
@@ -260,7 +260,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 		// aquire an agent and register handlers if needed
 		// this allows agent crash/restart to recover
-		stub := a.client.agent()
+		stub := a.Client.Agent()
 		if stub == nil {
 			sleepOnError(fmt.Errorf("failed to create agent connection"))
 			continue
@@ -407,7 +407,7 @@ func (a *Agent) invokeHandler(ctx context.Context, invoke *pb.DispatchHandlerInv
 	}
 
 	go func() {
-		apiStub := a.client.api()
+		apiStub := a.Client.Api()
 
 		wrapped := zapcore.RegisterHooks(a.logger.Core(), func(entry zapcore.Entry) error {
 			report.Logs = append(report.Logs, &pb.Log{
@@ -453,7 +453,7 @@ func (a *Agent) invokeHandler(ctx context.Context, invoke *pb.DispatchHandlerInv
 			zap.Any("error", report.GetError()),
 		)
 	}
-	_, err := a.client.agent().ReportInvocation(context.Background(), report)
+	_, err := a.Client.Agent().ReportInvocation(context.Background(), report)
 	if err != nil {
 		a.logger.Error("failed to report invocation", zap.Error(err))
 	}

--- a/axon_agent_test.go
+++ b/axon_agent_test.go
@@ -227,11 +227,11 @@ func TestInvokeHandlerApiCallWithError(t *testing.T) {
 
 func createAgent(controller *gomock.Controller) (*Agent, *mockGrpcClient) {
 	agent := NewAxonAgent(WithSleepOnError(0))
-	agent.client = &mockGrpcClient{
+	agent.Client = &mockGrpcClient{
 		apiStub:   mock_axon.NewMockCortexApiClient(controller),
 		agentStub: mock_axon.NewMockAxonAgentClient(controller),
 	}
-	return agent, agent.client.(*mockGrpcClient)
+	return agent, agent.Client.(*mockGrpcClient)
 }
 
 type agentCallback func(*mockGrpcClient)
@@ -304,11 +304,11 @@ type mockGrpcClient struct {
 	agentStub *mock_axon.MockAxonAgentClient
 }
 
-func (m *mockGrpcClient) api() pb.CortexApiClient {
+func (m *mockGrpcClient) Api() pb.CortexApiClient {
 	return m.apiStub
 }
 
-func (m *mockGrpcClient) agent() pb.AxonAgentClient {
+func (m *mockGrpcClient) Agent() pb.AxonAgentClient {
 	return m.agentStub
 }
 

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -12,8 +12,8 @@ import (
 // grpcClient is an interface to abstract the grpc client
 // to make this system more testable
 type grpcClient interface {
-	api() pb.CortexApiClient
-	agent() pb.AxonAgentClient
+	Api() pb.CortexApiClient
+	Agent() pb.AxonAgentClient
 }
 
 type grpcClientImpl struct {
@@ -51,7 +51,7 @@ func (c *grpcClientImpl) getConnection() *grpc.ClientConn {
 	return c.conn
 }
 
-func (c *grpcClientImpl) agent() pb.AxonAgentClient {
+func (c *grpcClientImpl) Agent() pb.AxonAgentClient {
 	if c.stub == nil {
 		conn := c.getConnection()
 		if conn == nil {
@@ -62,7 +62,7 @@ func (c *grpcClientImpl) agent() pb.AxonAgentClient {
 	return c.stub
 }
 
-func (c *grpcClientImpl) api() pb.CortexApiClient {
+func (c *grpcClientImpl) Api() pb.CortexApiClient {
 	if c.apiClientStub == nil {
 		conn := c.getConnection()
 		if conn == nil {


### PR DESCRIPTION
**Motivation**
 
Currently my team is building a service that schedules tasks that push data to Cortex. We plan to start with using Axon as it has the functionality we need: api client and scheduling. In the long term we'd like to have the option to switch to distributed scheduling.

That being said, we want to build an interface to the Axon agent that makes it easy for us to switch the scheduling implementation later on.Also, we are building a "provider" pattern where a provider encapsulate the logic to "provide" data into Cortex. Exposing the API client will help achieve this,  so we can inject the client into the "data provider" as follow (this is a simplified version of what we are trying to achieve):

```
type DataProvider struct {
	schedule string
	apiClient pb.CortexApiClient
}

func (d * DataProvider) Provide() void {
       // push data here
       d.apiClient.Call(...)
}

func scheduleProvider(provider DataProvider, axonAgent axonAgent) {
   // This is where we register the handler of the data provider
   // Later on we can switch the scheduling logic to whatever scheduler we want to use
   // Currently it just register it to axon
}

func main () {
   agent := axon.NewAxonAgent();
   apiClient := agent.Client.Api(); // This also allow us to create a wrapper on the client if needed
   
   providerA := &DataProvider{apiClient: apiClient};

   scheduleProvider(providerA, agent)
   
   agent.Run()
}
```